### PR TITLE
Fix metadata typo and z-index classes

### DIFF
--- a/components/MacMenuBar.tsx
+++ b/components/MacMenuBar.tsx
@@ -136,14 +136,14 @@ export const MacMenuBar: React.FC<MacMenuBarProps> = ({
             >
               {item}
               {fileOpen && !disableFile && (
-                <div className="absolute left-0 top-full mt-1 w-32 bg-white border border-gray-200 rounded shadow-lg py-1 z-60">
+                <div className="absolute left-0 top-full mt-1 w-32 bg-white border border-gray-200 rounded shadow-lg py-1 z-[60]">
                   <div className="relative group">
                     <div className="px-4 py-1 hover:bg-gray-100 cursor-pointer flex justify-between items-center">
                       Add
                       <span className="ml-2">&#9654;</span>
                     </div>
                     {/* Submenu */}
-                    <div className="absolute left-full top-0 mt-0 ml-1 w-36 bg-white border border-gray-200 rounded shadow-lg py-1 z-70">
+                    <div className="absolute left-full top-0 mt-0 ml-1 w-36 bg-white border border-gray-200 rounded shadow-lg py-1 z-[70]">
                       <div
                         className="px-4 py-1 hover:bg-gray-100 cursor-pointer"
                         onClick={() => addSector("health", onAddHealth)}
@@ -193,7 +193,7 @@ export const MacMenuBar: React.FC<MacMenuBarProps> = ({
             >
               {item}
               {historyOpen && (
-                <div className="absolute left-0 top-full mt-1 w-32 bg-white border border-gray-200 rounded shadow-lg py-1 z-60">
+                <div className="absolute left-0 top-full mt-1 w-32 bg-white border border-gray-200 rounded shadow-lg py-1 z-[60]">
                   <Link
                     href="/history?volume=1"
                     target="_blank"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,10 @@ import HomeClient from "./HomeClient";
 // Add metadata export at the top level of the file
 export const metadata = {
   title: "Horizon Shift Int 002",
-  description: "Explore NIS's Horizon Shift Volume 002 interactively. The report covers 3 key sectors: Eduation, Entertainment, and Health through strategic foresight frameworks.",
+  description: "Explore NIS's Horizon Shift Volume 002 interactively. The report covers 3 key sectors: Education, Entertainment, and Health through strategic foresight frameworks.",
   openGraph: {
     title: "Horizon Shift 002",
-    description: "Explore NIS's Horizon Shift Volume 002 interactively. The report covers 3 key sectors: Eduation, Entertainment, and Health through strategic foresight frameworks.",
+    description: "Explore NIS's Horizon Shift Volume 002 interactively. The report covers 3 key sectors: Education, Entertainment, and Health through strategic foresight frameworks.",
     url: "https://horizon-shift-git-main-khanikad-ucedus-projects.vercel.app/",
     siteName: "Horizon Shift 002",
     images: [


### PR DESCRIPTION
## Summary
- fix `Eduation` typo in page metadata
- use Tailwind arbitrary z-index utilities for dropdown menus

## Testing
- `yarn install`
- `npx next lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683f4df3ee1c8329b96c8bf42adf9e0a