### PR TITLE
Fix History tab Issuu preview links

### DIFF
--- a/src/app/history/HistoryClient.tsx
+++ b/src/app/history/HistoryClient.tsx
@@ -13,8 +13,8 @@ export default function HistoryClient() {
   const volume = searchParams.get("volume") || "1";
   const iframeSrc =
     volume === "2"
-      ? "https://issuu.com/uc_next_innovation_scholars/docs/horizon_shift_volume_002_future_creators_report?mode=window&viewMode=singlePage"
-      : "https://issuu.com/uc_next_innovation_scholars/docs/2023_uc_nis_future_creators_report_horizon_shift?mode=window&viewMode=singlePage";
+      ? "https://e.issuu.com/embed.html?d=horizon_shift_volume_002_future_creators_report&u=uc_next_innovation_scholars&hideIssuuLogo=true"
+      : "https://e.issuu.com/embed.html?d=2023_uc_nis_future_creators_report_horizon_shift&u=uc_next_innovation_scholars&hideIssuuLogo=true";
 
   return (
     <>


### PR DESCRIPTION
## Summary
- update `/history` iframe URL to use official Issuu embed links

## Testing
- `yarn lint`
- `tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6867b8b92dcc83299a74b9347edf063e