### PR TITLE
Fix streaming response in simulate API

### DIFF
--- a/src/app/api/simulate/route.ts
+++ b/src/app/api/simulate/route.ts
@@ -1,7 +1,6 @@
 // src/app/api/simulate/route.ts
 import { groq } from '@ai-sdk/groq';
 import { streamText } from 'ai';
-import { NextResponse } from 'next/server';
 
 export const runtime = 'edge'; // deploys as Edge Function
 
@@ -48,10 +47,10 @@ Output rules
 Begin.
 `;
 
-  const { textStream } = await streamText({
+  const result = await streamText({
     model: groq('llama-3.1-8b-instant'),
     prompt,
   });
 
-  return new NextResponse(textStream);
+  return result.toTextStreamResponse();
 }


### PR DESCRIPTION
## Summary
- use AI SDK helper to construct a valid streaming response

## Testing
- `yarn lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6867c0667c6c83298e1c3f26e7ca18a2